### PR TITLE
Add PWA icon

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -60,4 +60,6 @@ inkscape src/svg/icon/16.svg --export-png=favicon-16x16.png -w16 -h16
 inkscape src/svg/icon/16.svg --export-png=favicon-24x24.png -w24 -h24
 inkscape src/svg/icon/16.svg --export-png=favicon-32x32.png -w32 -h32
 inkscape src/svg/icon/16.svg --export-png=favicon-64x64.png -w64 -h64
+inkscape src/svg/icon/48.svg --export-png=img/logo-512x512.png -w512 -h512
+inkscape src/svg/icon/square.svg --export-png=img/maskable-192x192.png -w192 -h192
 convert favicon-16x16.png favicon-24x24.png favicon-32x32.png favicon-64x64.png favicon.ico

--- a/index.php
+++ b/index.php
@@ -70,7 +70,7 @@ Query parameters:
 		<meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="theme-color" content="white"/>
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
-    <link rel="apple-touch-icon" href="/img/logo.png">
+    <link rel="apple-touch-icon" href="/img/maskable-192x192.png">
     <link rel="manifest" href="/manifest.json">
 
 		<link rel="shortcut icon" href="favicon-32x32.png" />

--- a/index.php
+++ b/index.php
@@ -68,6 +68,10 @@ Query parameters:
 		<meta name="viewport" content="width=device-width, user-scalable=no" />
 		<meta name="mobile-web-app-capable" content="yes">
 		<meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="theme-color" content="white"/>
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
+    <link rel="apple-touch-icon" href="/img/logo.png">
+    <link rel="manifest" href="/manifest.json">
 
 		<link rel="shortcut icon" href="favicon-32x32.png" />
 		<?php echo "<title>".$metadata["title"]."</title>"; ?>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,30 @@
+{
+  "name": "MolView",
+  "short_name": "MolView",
+  "theme_color": "white",
+  "background_color": "white",
+  "display": "standalone",
+  "scope": "/",
+  "start_url": "/",
+  "icons": [{
+    "src": "img/logo.png",
+    "sizes": "256x256",
+    "type": "image/png"
+  }, {
+    "src": "favicon-64x64.png",
+    "sizes": "64x64",
+    "type": "image/png"
+  }, {
+    "src": "favicon-32x32.png",
+    "sizes": "32x32",
+    "type": "image/png"
+  }, {
+    "src": "favicon-24x24.png",
+    "sizes": "24x24",
+    "type": "image/png"
+  }, {
+    "src": "favicon-16x16.png",
+    "sizes": "16x16",
+    "type": "image/png"
+  }]
+}

--- a/manifest.json
+++ b/manifest.json
@@ -7,9 +7,18 @@
   "scope": "/",
   "start_url": "/",
   "icons": [{
+    "src": "img/logo-512x512.png",
+    "sizes": "512x512",
+    "type": "image/png"
+  }, {
     "src": "img/logo.png",
     "sizes": "256x256",
     "type": "image/png"
+  }, {
+    "src": "img/maskable-192x192.png",
+    "sizes": "192x192",
+    "type": "image/png",
+    "purpose": "maskable"
   }, {
     "src": "favicon-64x64.png",
     "sizes": "64x64",


### PR DESCRIPTION
I understand that this repo isn't under active development, but this change should be fairly easy to incorporate as it doesn't change any app logic. All that has changed is that the app icon when "installed" should reflect the MolView icon. This works on both Android, iOS, and computers.

As seen in the image, the app on the left is the improved version, while the right is the current version. While there isn't any major issue with the current icon, it is a nice quality of life improvement.

before | after
----- | -----
![before](https://user-images.githubusercontent.com/53224922/94695145-2bcf8800-02fb-11eb-9cd4-b84d97c042d2.png) | ![after](https://user-images.githubusercontent.com/53224922/94695203-4275df00-02fb-11eb-9b55-5889bcb2b64d.png)

